### PR TITLE
Get leveldb-dev from main repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./VERSION /tmp
 RUN VERSION=$(cat /tmp/VERSION) && \
     chmod a+x /usr/local/bin/* && \
     apk add --no-cache git build-base openssl && \
-    apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community leveldb-dev && \
+    apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main leveldb-dev && \
     apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing rocksdb-dev && \
     pip install aiohttp pylru plyvel websockets python-rocksdb && \
     git clone -b $VERSION https://github.com/kyuupichan/electrumx.git && \


### PR DESCRIPTION
The build currently fails with:

```
ERROR: unsatisfiable constraints:
leveldb-dev (missing):
required by: world[leveldb-dev]
```

Looks like the package was moved from the `community` to the `main` repository.